### PR TITLE
Improved lift coefficient function

### DIFF
--- a/Lockheed1049h.xml
+++ b/Lockheed1049h.xml
@@ -1132,10 +1132,17 @@ K:             0.039
           <table>
             <independentVar>aero/alpha-rad</independentVar>
             <tableData>
-              -0.2000	-0.5000	                                     <!-- aeromatic -0.740 -->
-              0.0000	0.0000	                                     <!-- aeromatic  0.240 -->
-              0.2400	1.1600	                                     <!-- aeromatic  1.400 -->
-              0.6000	0.4640	                                     <!-- aeromatic  0.704 -->
+                -0.20	-0.5
+                -0.10	-0.4
+                -0.05	-0.3
+                 0.00	 0
+                 0.04	 0.5
+                 0.08	 0.8
+                 0.16	 1.08
+                 0.24	 1.16
+                 0.32	 1.1
+                 0.48	 0.832
+                 0.6	 0.464
             </tableData>
           </table>
         </product>


### PR DESCRIPTION
Process:

- Test flight climbing to FL200 at MTOW and maintaining level flight with A/P. Note 8° nose-up attitude.
- Calculate CLalpha at 8° nose-up from old lift function
- Insert entry into lift table for 2.5° nose-up and the calculated CLalpha
- Insert additional entries to smooth out the lift curve (eyeball)

Before (pink) & after (blue):

![scrot](https://user-images.githubusercontent.com/1434567/182123423-d27ae20a-2c2c-402e-b58a-1b8974ce5ae9.png)

The aircraft now climbs more eagerly at sea level, and produces more realistic pitch attitudes in level flight when cruising heavy.